### PR TITLE
I fixed the endpoint suffix that was misspelled.

### DIFF
--- a/src/app/features/graph-editor/services/graph-editor.service.ts
+++ b/src/app/features/graph-editor/services/graph-editor.service.ts
@@ -126,7 +126,7 @@ export class GraphEditorService {
     const url = `${environment.apiUrl}`;
 
     try {
-      const response = await fetch(url+"/create_app", {
+      const response = await fetch(getBaseURL("/api/get_config"), {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/features/graph-editor/services/graph-editor.service.ts
+++ b/src/app/features/graph-editor/services/graph-editor.service.ts
@@ -126,7 +126,7 @@ export class GraphEditorService {
     const url = `${environment.apiUrl}`;
 
     try {
-      const response = await fetch(url, {
+      const response = await fetch(url+"/create_app", {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/src/app/shared/utils.ts
+++ b/src/app/shared/utils.ts
@@ -41,7 +41,7 @@ export function getColorFromCategory(category: string): string {
 
 export function getBaseURL(suffix = ""): string {
   if (isDevMode()) {
-    return "http://localhost:5030" + suffix;
+    return "http://localhost:5000" + suffix;
   }
 
   return "https://gessi.cs.upc.edu:1446" + suffix;


### PR DESCRIPTION
In the file graph-editor.service.ts, the endpoint suffix was pointing to the wrong server, so the server couldn’t find anything and nothing appeared in the graphic editor. I changed the endpoint so it points correctly now